### PR TITLE
Added required Clojars and made link to docs more obvious.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ plugins {
   id "dev.clojurephant.clojure" version "<version>"
 }
 
+// You need to add clojars for the plugin to work.
+repositories {
+  maven {
+    name = 'Clojars' // name can be ommitted, but is helpful in troubleshooting
+    url = 'https://repo.clojars.org/'
+  }
+}
+
 dependencies {
   // whatever version of clojure you prefer (versions before 1.8.0 may not be compatible)
   implementation 'org.clojure:clojure:1.10.0'
@@ -98,6 +106,9 @@ dependencies {
 See all available options in the [docs](https://clojurephant.dev).
 
 ## Getting help
+
+
+Read the online Clojurephant documentation [https://clojurephant.dev](https://clojurephant.dev).
 
 For questions or support, please visit either the [ClojureVerse gradle-clojure channel](https://clojureverse.org/c/projects/gradle-clojure) or the [Clojurian's Slack #gradle channel](http://clojurians.net/)
 

--- a/docs/new-gradle.md
+++ b/docs/new-gradle.md
@@ -50,7 +50,7 @@ See [Gradle's Introduction to Dependency Management](https://docs.gradle.org/cur
 
 No repositories are specified by default, so you must list any repositories you want to search for your dependencies.
 
-**IMPORTANT:** clojurephant currently requires `jcenter()` (or `mavenCentral()` and Clojars) be included in your repository list.
+**IMPORTANT:** clojurephant currently requires `jcenter()` (or `mavenCentral()`) and Clojars be included in your repository list.
 
 ```groovy
 repositories {


### PR DESCRIPTION
<!-- Why is this change being made? -->

Clojars is required. jcenter is not enough. Updated docs and made link more obvious. Repetition is king. 

**Related issues:**
https://github.com/clojurephant/clojurephant/issues/68

## Contributor Checklist

- [x] Review [Contributing Guidelines](https://github.com/clojurephant/clojurephant/blob/master/.github/CONTRIBUTING.md).
- [x] Commits contain discrete changes, messages include context about why the change was made and reference the relevant issues.
- [-] Provide functional tests. (under `modules/clojurephant-plugin/src/compatTest`)
- [x] Update documentation for user-facing changes. (under `docs/`)
- [x] Ensure all verification tasks pass locally. (`./gradlew check`)
- [x] Ensure CI builds pass on all Java versions. (watch the checks tab once the PR is opened)

  **TIP:** If troubleshooting a CI failure, look for the build scan URL near the bottom of the Gradle output.
