### PR TITLE
Fix for multi-project classpath issues

### DIFF
--- a/clojurephant-plugin/src/compatTest/clojure/dev/clojurephant/compat_test/multi_project.clj
+++ b/clojurephant-plugin/src/compatTest/clojure/dev/clojurephant/compat_test/multi_project.clj
@@ -1,0 +1,20 @@
+(ns dev.clojurephant.compat-test.multi-project
+  (:require [clojure.set :as set]
+            [clojure.string :as str]
+            [clojure.test :refer :all]
+            [dev.clojurephant.compat-test.test-kit :as gradle]
+            [ike.cljj.file :as file])
+  (:import [org.gradle.testkit.runner TaskOutcome]))
+
+(deftest multi-project-classpath
+  (testing "with multi-project and AOT off, project B sources and dependencies are on classpath of A"
+    (gradle/with-project "MultiProjectTest"
+      (let [result (gradle/build "jar")]
+        (gradle/verify-task-outcome result ":SubClojureB:compileClojure" :skipped)
+        (gradle/verify-task-outcome result ":SubClojureB:checkClojure" :success)
+        (gradle/verify-task-outcome result ":SubClojureB:jar" :success)
+        (gradle/verify-task-outcome result ":SubClojureA:compileClojure" :skipped)
+        (gradle/verify-task-outcome result ":SubClojureA:checkClojure" :success)
+        (gradle/verify-task-outcome result ":SubClojureA:jar" :success)
+        (gradle/verify-jar-contents ["SubClojureA/src/main/clojure" "SubClojureA/src/main/resources"] "SubClojureA/build/libs/SubClojureA.jar")
+        (gradle/verify-jar-contents ["SubClojureB/src/main/clojure" "SubClojureB/src/main/resources"] "SubClojureB/build/libs/SubClojureB.jar")))))

--- a/clojurephant-plugin/src/compatTest/clojure/dev/clojurephant/compat_test/test_kit.clj
+++ b/clojurephant-plugin/src/compatTest/clojure/dev/clojurephant/compat_test/test_kit.clj
@@ -33,7 +33,9 @@
         xf (comp (drop 1)
                  (filter file/file?)
                  (map (fn [f] (.relativize root f))))]
-    (into #{} xf (file/walk root))))
+    (if (file/exists? root)
+      (into #{} xf (file/walk root))
+      #{})))
 
 (defn verify-compilation-without-aot
   [src-dir dst-dir]

--- a/clojurephant-plugin/src/compatTest/projects/MultiProjectTest/SubClojureA/build.gradle
+++ b/clojurephant-plugin/src/compatTest/projects/MultiProjectTest/SubClojureA/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+  id 'dev.clojurephant.clojure'
+  id 'java-library'
+}
+
+dependencies {
+  api 'org.clojure:clojure:1.8.0'
+  api project(':SubClojureB')
+}

--- a/clojurephant-plugin/src/compatTest/projects/MultiProjectTest/SubClojureA/src/main/clojure/clja/core.clj
+++ b/clojurephant-plugin/src/compatTest/projects/MultiProjectTest/SubClojureA/src/main/clojure/clja/core.clj
@@ -1,0 +1,5 @@
+(ns clja.core
+  (:require [cljb.core :as cljb]))
+
+(defn process []
+  (:my-key (cljb/read-data)))

--- a/clojurephant-plugin/src/compatTest/projects/MultiProjectTest/SubClojureB/build.gradle
+++ b/clojurephant-plugin/src/compatTest/projects/MultiProjectTest/SubClojureB/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+  id 'dev.clojurephant.clojure'
+  id 'java-library'
+}
+
+dependencies {
+  api 'org.clojure:clojure:1.8.0'
+  api 'org.clojure:data.json:1.0.0'
+}

--- a/clojurephant-plugin/src/compatTest/projects/MultiProjectTest/SubClojureB/src/main/clojure/cljb/core.clj
+++ b/clojurephant-plugin/src/compatTest/projects/MultiProjectTest/SubClojureB/src/main/clojure/cljb/core.clj
@@ -1,0 +1,5 @@
+(ns cljb.core
+  (:require [clojure.data.json :as json]))
+
+(defn read-data []
+  (json/read-str "{ \"my-key\": 123 }"))

--- a/clojurephant-plugin/src/compatTest/projects/MultiProjectTest/build.gradle
+++ b/clojurephant-plugin/src/compatTest/projects/MultiProjectTest/build.gradle
@@ -1,0 +1,12 @@
+subprojects {
+  plugins.withId('dev.clojurephant.clojure') {
+    repositories {
+      mavenCentral()
+      maven {
+        name = 'Clojars'
+        url = 'https://repo.clojars.org/'
+      }
+      mavenLocal()
+    }
+  }
+}

--- a/clojurephant-plugin/src/compatTest/projects/MultiProjectTest/settings.gradle
+++ b/clojurephant-plugin/src/compatTest/projects/MultiProjectTest/settings.gradle
@@ -1,0 +1,3 @@
+include 'SubClojureA'
+include 'SubClojureB'
+include 'SubJavaC'

--- a/clojurephant-plugin/src/main/java/dev/clojurephant/plugin/clojure/ClojureBasePlugin.java
+++ b/clojurephant-plugin/src/main/java/dev/clojurephant/plugin/clojure/ClojureBasePlugin.java
@@ -45,17 +45,18 @@ public class ClojureBasePlugin implements Plugin<Project> {
 
       ClojureBuild build = extension.getBuilds().create(sourceSet.getName());
       build.getSourceSet().set(sourceSet);
-      ((DefaultSourceSetOutput) sourceSet.getOutput()).addClassesDir(() -> build.getOutputDir().get().getAsFile());
-      project.getTasks().getByName(sourceSet.getClassesTaskName()).dependsOn(build.getTaskName("compile"));
-      project.getTasks().getByName(sourceSet.getClassesTaskName()).dependsOn(build.getTaskName("check"));
 
-      sourceSet.getOutput().dir(project.provider(() -> {
+      Provider<FileCollection> output = project.provider(() -> {
         if (build.isCompilerConfigured()) {
-          return build.getOutputDir();
+          return project.files(build.getOutputDir());
         } else {
           return clojureSourceSet.getClojure().getSourceDirectories();
         }
-      }));
+      });
+
+      ((DefaultSourceSetOutput) sourceSet.getOutput()).getClassesDirs().from(output);
+      project.getTasks().getByName(sourceSet.getClassesTaskName()).dependsOn(build.getTaskName("compile"));
+      project.getTasks().getByName(sourceSet.getClassesTaskName()).dependsOn(build.getTaskName("check"));
     });
   }
 


### PR DESCRIPTION
The java-library plugin causes selection of a secondary classes variant
of the project dependency, which will cause only the registered
classesDirs to be put on the classpath.

In order to make this work the simplest, we need to have the Clojure
plugins register their source directories as classes dirs, if the
compiler isn't configured.

This fixes #128 and #134.

<!-- Why is this change being made? -->

**Related issues:**

## Contributor Checklist

- [ ] Review [Contributing Guidelines](https://github.com/clojurephant/clojurephant/blob/master/.github/CONTRIBUTING.md).
- [ ] Commits contain discrete changes, messages include context about why the change was made and reference the relevant issues.
- [ ] Provide functional tests. (under `modules/clojurephant-plugin/src/compatTest`)
- [ ] Update documentation for user-facing changes. (under `docs/`)
- [ ] Ensure all verification tasks pass locally. (`./gradlew check`)
- [ ] Ensure CI builds pass on all Java versions. (watch the checks tab once the PR is opened)

  **TIP:** If troubleshooting a CI failure, look for the build scan URL near the bottom of the Gradle output.
