### PR TITLE
[#148] Avoid NPE on failed compile

### DIFF
--- a/clojurephant-tools/src/main/clojure/dev/clojurephant/tools/clojure_compiler.clj
+++ b/clojurephant-tools/src/main/clojure/dev/clojurephant/tools/clojure_compiler.clj
@@ -7,16 +7,17 @@
 (defn -main [& args]
   (log :debug "Classpath: %s" (System/getProperty "java.class.path"))
   (let [[destination-dir namespaces options] (edn/read)]
-    (try
-      (binding [*namespaces* (seq namespaces)
-                *compile-path* destination-dir
-                *compiler-options* options]
-        (doseq [namespace namespaces]
+    (binding [*namespaces* (seq namespaces)
+              *compile-path* destination-dir
+              *compiler-options* options]
+      (doseq [namespace namespaces]
+        (try
           (log :info "Compiling %s" namespace)
-          (compile (symbol namespace))))
-      (catch Throwable e
-        (loop [ex e]
-          (if-let [msg (and ex (.getMessage ex))]
-            (log :error msg)
-            (recur (.getCause ex))))
-        (throw e)))))
+          (compile (symbol namespace))
+          (catch Throwable e
+            (loop [ex e]
+              (when-let [msg (and ex (.getMessage ex))]
+                (log :error "Failed to compile %s" namespace)
+                (log :error msg))
+              (when ex (recur (.getCause ex))))
+            (throw e)))))))


### PR DESCRIPTION
This change also logs the namespace which fails to compile.

<!-- Why is this change being made? -->

**Related issues:** #148 

## Contributor Checklist

- [X] Review [Contributing Guidelines](https://github.com/clojurephant/clojurephant/blob/master/.github/CONTRIBUTING.md).
- [X] Commits contain discrete changes, messages include context about why the change was made and reference the relevant issues.
- [x] Provide functional tests. (under `modules/clojurephant-plugin/src/compatTest`)
- [x] Update documentation for user-facing changes. (under `docs/`)
- [X] Ensure all verification tasks pass locally. (`./gradlew check`)
- [x] Ensure CI builds pass on all Java versions. (watch the checks tab once the PR is opened)

  **TIP:** If troubleshooting a CI failure, look for the build scan URL near the bottom of the Gradle output.
