### PR TITLE
Keep compiled dev cljs on classpath for REPL

### DIFF
--- a/clojurephant-plugin/src/compatTest/clojure/dev/clojurephant/compat_test/repl.clj
+++ b/clojurephant-plugin/src/compatTest/clojure/dev/clojurephant/compat_test/repl.clj
@@ -99,11 +99,10 @@
 
 
 (deftest no-compile-output-on-classpath
-  (testing "Compile output from other tasks should not be on classpath of the REPL"
+  (testing "Compile output from other tasks (besides dev cljs) should not be on classpath of the REPL"
     (with-client [client "BasicClojureScriptProjectTest"]
       (let [output-dirs (into #{} (map file/path) ["build/clojurescript/main"
                                                    "build/clojurescript/test"
-                                                   "build/clojurescript/dev"
                                                    "build/clojure/main"
                                                    "build/clojure/test"
                                                    "build/clojure/dev"])


### PR DESCRIPTION
This allows you to use Gradle to do a continuous build of the CLJS.

<!-- Why is this change being made? -->

**Related issues:**

## Contributor Checklist

- [x] Review [Contributing Guidelines](https://github.com/clojurephant/clojurephant/blob/master/.github/CONTRIBUTING.md).
- [x] Commits contain discrete changes, messages include context about why the change was made and reference the relevant issues.
- [x] Commit messages should be prefixed with one of the following (these are used to determine the next version we release):
  - `patch: ` if the change added no new functionality and is backwards compatible
  - `minor: ` if the change added new functionality and is backwards compatible
  - `major: ` if the change is not backwards compatible
  - `chore: ` if the change doesn't affect plugin logic/behavior at all (and obviously still backwards compatible)
  - Any of these can optionally specify an area of the plugin they affected in parentheses (e.g. `patch(clojurescript): `)
    - `build`
    - `docs`
    - `clojure`
    - `clojurescript`
    - `common`
    - `repl`
- [x] Provide functional tests. (under `clojurephant-plugin/src/compatTest`)
- [x] Update documentation for user-facing changes. (under `docs/`)
- [x] Ensure all verification tasks pass locally. (`./gradlew check`)
- [x] Ensure CI builds pass on all Java versions. (watch the checks tab once the PR is opened)

**TIP:** If troubleshooting a CI failure, look for the build scan URL in the workflow run summary.
