### PR TITLE
Support Gradle's configuration cache

### DIFF
--- a/src/compatTest/clojure/dev/clojurephant/compat_test/test_kit.clj
+++ b/src/compatTest/clojure/dev/clojurephant/compat_test/test_kit.clj
@@ -66,7 +66,7 @@
   (println "***** Args:" args "*****")
   (-> (GradleRunner/create)
       (.withProjectDir (-> *project-dir* .toFile))
-      (.withArguments (into-array String (conj args "--stacktrace")))
+      (.withArguments (into-array String (conj args "--stacktrace" "--configuration-cache")))
       (.withPluginClasspath)
       (.forwardOutput)))
 

--- a/src/compatTest/clojure/dev/clojurephant/compat_test/uberjar.clj
+++ b/src/compatTest/clojure/dev/clojurephant/compat_test/uberjar.clj
@@ -10,6 +10,7 @@
 (deftest uberjar-application
   (testing "an application uberjar can have its main ns run"
     (gradle/with-project "UberjarTest"
-      (let [result (gradle/build "runShadow" "-q")]
+      ;; Shadow plugin 7.1.2 is incompatible with configuration cache https://github.com/johnrengelman/shadow/issues/775
+      (let [result (gradle/build "runShadow" "-q" "--no-configuration-cache")]
         (gradle/verify-task-outcome result ":runShadow" :success)
         (is (str/includes? (.getOutput result) (str (LocalDate/now))))))))

--- a/src/compatTest/projects/UberjarTest/build.gradle
+++ b/src/compatTest/projects/UberjarTest/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'dev.clojurephant.clojure'
   id 'application'
-  id 'com.github.johnrengelman.shadow' version '6.1.0'
+  id 'com.github.johnrengelman.shadow' version '7.1.2'
 }
 
 mainClassName = 'sample.core'

--- a/src/main/java/dev/clojurephant/plugin/clojure/tasks/ClojureCompile.java
+++ b/src/main/java/dev/clojurephant/plugin/clojure/tasks/ClojureCompile.java
@@ -16,6 +16,7 @@ import dev.clojurephant.plugin.common.internal.PreplClient;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileSystemOperations;
@@ -57,13 +58,9 @@ public abstract class ClojureCompile extends DefaultTask {
   @InputFiles
   @SkipWhenEmpty
   @IgnoreEmptyDirectories
-  public FileTree getSource() {
-    // TODO can this be done another way?
-    return Namespaces.getSources(getSourceRoots(), Namespaces.CLOJURE_EXTENSIONS);
-  }
+  public abstract FileTree getSource();
 
-  @Internal
-  public abstract ConfigurableFileCollection getSourceRoots();
+  public abstract void setSource(FileTree fileTree);
 
   @Classpath
   public abstract ConfigurableFileCollection getClasspath();
@@ -101,7 +98,6 @@ public abstract class ClojureCompile extends DefaultTask {
     logger.info("Compiling {}", String.join(", ", namespaces));
 
     FileCollection classpath = getClasspath()
-        .plus(getSourceRoots())
         .plus(getProjectLayout().files(outputDir));
 
     PreplClient preplClient = prepl.start(spec -> {

--- a/src/main/java/dev/clojurephant/plugin/clojurescript/ClojureScriptBasePlugin.java
+++ b/src/main/java/dev/clojurephant/plugin/clojurescript/ClojureScriptBasePlugin.java
@@ -6,6 +6,7 @@ import dev.clojurephant.plugin.clojurescript.internal.DefaultClojureScriptSource
 import dev.clojurephant.plugin.clojurescript.tasks.ClojureScriptCompile;
 import dev.clojurephant.plugin.clojurescript.tasks.ClojureScriptSourceSet;
 import dev.clojurephant.plugin.common.internal.ClojureCommonBasePlugin;
+import dev.clojurephant.plugin.common.internal.Namespaces;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
@@ -38,12 +39,18 @@ public class ClojureScriptBasePlugin implements Plugin<Project> {
       new DslObject(sourceSet).getConvention().getPlugins().put("clojurescript", clojurescriptSourceSet);
 
       clojurescriptSourceSet.getClojureScript().srcDir(String.format("src/%s/clojurescript", sourceSet.getName()));
+      clojurescriptSourceSet.getClojureScript().getFilter().include(Namespaces.CLOJURESCRIPT_PATTERNS);
       // in case the clojure source overlaps with the resources source
       sourceSet.getResources().getFilter().exclude(element -> clojurescriptSourceSet.getClojureScript().contains(element.getFile()));
       sourceSet.getAllSource().source(clojurescriptSourceSet.getClojureScript());
 
       ClojureScriptBuild build = extension.getBuilds().create(sourceSet.getName());
-      build.getSourceSet().set(sourceSet);
+      ClojureScriptSourceSet clojurescript = (ClojureScriptSourceSet) new DslObject(sourceSet).getConvention().getPlugins().get("clojurescript");
+      build.getSourceRoots().from(clojurescript.getClojureScript().getSourceDirectories());
+
+      build.getClasspath()
+          .from(build.getSourceRoots())
+          .from(project.provider(() -> sourceSet.getCompileClasspath()));
 
       project.getTasks().named(sourceSet.getClassesTaskName(), task -> {
         task.dependsOn(build.getTaskName("compile"));
@@ -77,8 +84,8 @@ public class ClojureScriptBasePlugin implements Plugin<Project> {
       project.getTasks().register(compileTaskName, ClojureScriptCompile.class, task -> {
         task.setDescription(String.format("Compiles the ClojureScript source for the %s build.", build.getName()));
         task.getDestinationDir().set(build.getOutputDir());
-        task.getSourceRoots().from(build.getSourceRoots());
-        task.getClasspath().from(build.getSourceSet().map(SourceSet::getCompileClasspath));
+        task.setSource(build.getSourceTree());
+        task.getClasspath().from(build.getClasspath());
         task.getOptions().set(build.getCompiler());
       });
     });

--- a/src/main/java/dev/clojurephant/plugin/clojurescript/ClojureScriptBuild.java
+++ b/src/main/java/dev/clojurephant/plugin/clojurescript/ClojureScriptBuild.java
@@ -5,8 +5,11 @@ import dev.clojurephant.plugin.clojurescript.tasks.ClojureScriptSourceSet;
 import org.apache.commons.text.WordUtils;
 import org.gradle.api.Action;
 import org.gradle.api.Named;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -16,13 +19,12 @@ import org.gradle.api.tasks.SourceSet;
 public abstract class ClojureScriptBuild implements Named {
   public abstract DirectoryProperty getOutputDir();
 
-  public abstract Property<SourceSet> getSourceSet();
+  public abstract ConfigurableFileCollection getClasspath();
 
-  Provider<FileCollection> getSourceRoots() {
-    return getSourceSet().map(sourceSet -> {
-      ClojureScriptSourceSet clojure = (ClojureScriptSourceSet) new DslObject(sourceSet).getConvention().getPlugins().get("clojurescript");
-      return clojure.getClojureScript().getSourceDirectories();
-    });
+  public abstract ConfigurableFileCollection getSourceRoots();
+
+  public FileTree getSourceTree() {
+    return getSourceRoots().getAsFileTree();
   }
 
   boolean isCompilerConfigured() {

--- a/src/main/java/dev/clojurephant/plugin/clojurescript/tasks/ClojureScriptCompile.java
+++ b/src/main/java/dev/clojurephant/plugin/clojurescript/tasks/ClojureScriptCompile.java
@@ -16,6 +16,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.IgnoreEmptyDirectories;
@@ -60,12 +61,14 @@ public abstract class ClojureScriptCompile extends DefaultTask {
   @Nested
   public abstract ForkOptions getForkOptions();
 
+  @Inject
+  protected abstract FileSystemOperations getFileSystemOperations();
+
   @TaskAction
   public void compile() {
     File outputDir = getDestinationDir().get().getAsFile();
-    if (!getProject().delete(outputDir)) {
-      throw new GradleException("Cannot clean destination directory: " + outputDir.getAbsolutePath());
-    }
+    getFileSystemOperations().delete(spec -> spec.delete(outputDir));
+
     if (!outputDir.mkdirs()) {
       throw new GradleException("Cannot create destination directory: " + outputDir.getAbsolutePath());
     }

--- a/src/main/java/dev/clojurephant/plugin/clojurescript/tasks/ClojureScriptCompile.java
+++ b/src/main/java/dev/clojurephant/plugin/clojurescript/tasks/ClojureScriptCompile.java
@@ -14,9 +14,11 @@ import dev.clojurephant.plugin.common.internal.PreplClient;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.file.FileTree;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.IgnoreEmptyDirectories;
@@ -41,13 +43,9 @@ public abstract class ClojureScriptCompile extends DefaultTask {
   @InputFiles
   @SkipWhenEmpty
   @IgnoreEmptyDirectories
-  public FileCollection getSource() {
-    // TODO can this be done another way?
-    return Namespaces.getSources(getSourceRoots(), Namespaces.CLOJURESCRIPT_EXTENSIONS);
-  }
+  public abstract FileTree getSource();
 
-  @Internal
-  public abstract ConfigurableFileCollection getSourceRoots();
+  public abstract void setSource(FileTree fileTree);
 
   @OutputDirectory
   public abstract DirectoryProperty getDestinationDir();
@@ -73,10 +71,8 @@ public abstract class ClojureScriptCompile extends DefaultTask {
       throw new GradleException("Cannot create destination directory: " + outputDir.getAbsolutePath());
     }
 
-    FileCollection classpath = getClasspath().plus(getSourceRoots());
-
     PreplClient preplClient = prepl.start(spec -> {
-      spec.setClasspath(classpath);
+      spec.setClasspath(getClasspath());
       spec.setPort(0);
       spec.forkOptions(fork -> {
         fork.setJvmArgs(getForkOptions().getJvmArgs());
@@ -91,7 +87,7 @@ public abstract class ClojureScriptCompile extends DefaultTask {
       preplClient.evalEdn("(require '[cljs.build.api :as api])");
       List<?> form = Edn.list(
           Symbol.newSymbol("api", "build"),
-          Edn.list(Symbol.newSymbol("apply"), Symbol.newSymbol("api", "inputs"), getSourceRoots()),
+          Edn.list(Symbol.newSymbol("apply"), Symbol.newSymbol("api", "inputs"), getSource()),
           getOptions());
       preplClient.evalData(form);
       preplClient.evalEdn("(.flush *err*)");


### PR DESCRIPTION
To improve support for Gradle's configuration cache, we need to stop
using the getProject() method at execution time. We can replace this
with other interfaces that Gradle provides, so no harm here.

This does not fully address configuration cache support, but is the
first step.

<!-- Why is this change being made? -->

**Related issues:**

## Contributor Checklist

- [x] Review [Contributing Guidelines](https://github.com/clojurephant/clojurephant/blob/master/.github/CONTRIBUTING.md).
- [x] Commits contain discrete changes, messages include context about why the change was made and reference the relevant issues.
- [x] Commit messages should be prefixed with one of the following (these are used to determine the next version we release):
  - `patch: ` if the change added no new functionality and is backwards compatible
  - `minor: ` if the change added new functionality and is backwards compatible
  - `major: ` if the change is not backwards compatible
  - `chore: ` if the change doesn't affect plugin logic/behavior at all (and obviously still backwards compatible)
  - Any of these can optionally specify an area of the plugin they affected in parentheses (e.g. `patch(clojurescript): `)
    - `build`
    - `docs`
    - `clojure`
    - `clojurescript`
    - `common`
    - `repl`
- [x] Provide functional tests. (under `clojurephant-plugin/src/compatTest`)
- [x] Update documentation for user-facing changes. (under `docs/`)
- [x] Ensure all verification tasks pass locally. (`./gradlew check`)
- [x] Ensure CI builds pass on all Java versions. (watch the checks tab once the PR is opened)

**TIP:** If troubleshooting a CI failure, look for the build scan URL in the workflow run summary.
