### PR TITLE
patch(cursive): Fix detection of source roots in Intellij

### DIFF
--- a/manual-test/build.gradle
+++ b/manual-test/build.gradle
@@ -2,6 +2,7 @@ plugins {
   id 'dev.clojurephant.clojure'
   id 'dev.clojurephant.clojurescript'
   id 'eclipse'
+  id 'idea'
 }
 
 repositories {

--- a/src/main/java/dev/clojurephant/plugin/clojure/ClojureBasePlugin.java
+++ b/src/main/java/dev/clojurephant/plugin/clojure/ClojureBasePlugin.java
@@ -55,6 +55,7 @@ public class ClojureBasePlugin implements Plugin<Project> {
       sourceSet.getResources().getFilter().exclude(element -> clojureSource.contains(element.getFile()));
 
       // ensure that clojure is considered part of full source of source set
+      sourceSet.getAllJava().source(clojureSource);
       sourceSet.getAllSource().source(clojureSource);
 
       // every source set gets a default clojure build

--- a/src/main/java/dev/clojurephant/plugin/clojurescript/ClojureScriptBasePlugin.java
+++ b/src/main/java/dev/clojurephant/plugin/clojurescript/ClojureScriptBasePlugin.java
@@ -49,6 +49,7 @@ public class ClojureScriptBasePlugin implements Plugin<Project> {
       sourceSet.getResources().getFilter().exclude(element -> clojureScriptSource.contains(element.getFile()));
 
       // ensure that clojurescript is considered part of full source of source set
+      sourceSet.getAllJava().source(clojureScriptSource);
       sourceSet.getAllSource().source(clojureScriptSource);
 
       // every source set gets a default clojurescript build

--- a/src/main/java/dev/clojurephant/plugin/common/internal/ClojureCommonPlugin.java
+++ b/src/main/java/dev/clojurephant/plugin/common/internal/ClojureCommonPlugin.java
@@ -68,6 +68,8 @@ public class ClojureCommonPlugin implements Plugin<Project> {
     };
 
     dev.setCompileClasspath(project.files(
+        clojureSources.apply(test),
+        clojureSources.apply(main),
         main.getJava().getClassesDirectory(),
         project.getConfigurations().getByName(dev.getCompileClasspathConfigurationName())));
     dev.setRuntimeClasspath(project.files(


### PR DESCRIPTION
We needed to mark the Clojure/ClojureScript directories as part of
allJava SourceDirectorySet on each SourceSet, for Intellij's Gradle
integration to pick them up as source roots.

This fixes #160 and #108 and #66.

<!-- Why is this change being made? -->

**Related issues:**

## Contributor Checklist

- [ ] Review [Contributing Guidelines](https://github.com/clojurephant/clojurephant/blob/master/.github/CONTRIBUTING.md).
- [ ] Commits contain discrete changes, messages include context about why the change was made and reference the relevant issues.
- [ ] Commit messages should be prefixed with one of the following (these are used to determine the next version we release):
  - `patch: ` if the change added no new functionality and is backwards compatible
  - `minor: ` if the change added new functionality and is backwards compatible
  - `major: ` if the change is not backwards compatible
  - `chore: ` if the change doesn't affect plugin logic/behavior at all (and obviously still backwards compatible)
  - Any of these can optionally specify an area of the plugin they affected in parentheses (e.g. `patch(clojurescript): `)
    - `build`
    - `docs`
    - `clojure`
    - `clojurescript`
    - `common`
    - `repl`
- [ ] Provide functional tests. (under `clojurephant-plugin/src/compatTest`)
- [ ] Update documentation for user-facing changes. (under `docs/`)
- [ ] Ensure all verification tasks pass locally. (`./gradlew check`)
- [ ] Ensure CI builds pass on all Java versions. (watch the checks tab once the PR is opened)

**TIP:** If troubleshooting a CI failure, look for the build scan URL in the workflow run summary.
