### PR TITLE
minor(cider): Support jack-in of dependencies

### DIFF
--- a/manual-test/build.gradle
+++ b/manual-test/build.gradle
@@ -32,10 +32,6 @@ dependencies {
   implementation 'com.stuartsierra:component:1.1.0'
   devImplementation 'com.stuartsierra:component.repl:0.2.0'
 
-  // cider
-  devImplementation 'cider:cider-nrepl:0.28.5'
-  devImplementation 'cider:piggieback:0.5.3'
-
   // figwheel
   devImplementation 'com.bhauman:figwheel-repl:0.2.18'
   devImplementation 'ring:ring-jetty-adapter:1.9.5'
@@ -43,10 +39,6 @@ dependencies {
 
 tasks.withType(Test) {
   useJUnitPlatform()
-}
-
-tasks.named('clojureRepl') {
-  middleware = ['cider.nrepl/cider-middleware', 'cider.piggieback/wrap-cljs-repl']
 }
 
 clojure {

--- a/src/compatTest/clojure/dev/clojurephant/compat_test/repl.clj
+++ b/src/compatTest/clojure/dev/clojurephant/compat_test/repl.clj
@@ -68,6 +68,12 @@
       (is (= "0.28.2" (-> (send-repl client {:op "cider-version"}) :cider-version :version-string)))
       (is (pr-str 7) (eval-repl client '(do (require 'basic-project.core) (basic-project/use-ns 4)))))))
 
+(deftest cider-jack-in
+  (testing "nREPL dependencies can be jacked-in via command line"
+    (with-client [client "BasicClojureProjectTest" "--handler=cider.nrepl/cider-nrepl-handler" "-Pdev.clojurephant.jack-in.nrepl=nrepl:nrepl:0.9,cider:cider-nrepl:0.28.3"]
+      (is (= "0.28.3" (-> (send-repl client {:op "cider-version"}) :cider-version :version-string)))
+      (is (pr-str 7) (eval-repl client '(do (require 'basic-project.core) (basic-project/use-ns 4)))))))
+
 (deftest task-dependencies-clj
   (testing "No Clojure compiles happen when REPL is requested, but other languages are compiled"
     (gradle/with-project "MixedJavaClojureTest"

--- a/src/main/java/dev/clojurephant/plugin/common/internal/ClojureCommonBasePlugin.java
+++ b/src/main/java/dev/clojurephant/plugin/common/internal/ClojureCommonBasePlugin.java
@@ -1,14 +1,30 @@
 package dev.clojurephant.plugin.common.internal;
 
-
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.tasks.SourceSetContainer;
 
 public class ClojureCommonBasePlugin implements Plugin<Project> {
+  public static final String NREPL_JACK_IN_PROPERTY = "dev.clojurephant.jack-in.nrepl";
+
   @Override
   public void apply(Project project) {
     project.getPluginManager().apply(JavaBasePlugin.class);
+    configureNreplDependencies(project);
+  }
+
+  public void configureNreplDependencies(Project project) {
+    Configuration nrepl = project.getConfigurations().create(ClojureCommonPlugin.NREPL_CONFIGURATION_NAME);
+    if (project.hasProperty(NREPL_JACK_IN_PROPERTY)) {
+      String[] jackInDeps = project.findProperty(NREPL_JACK_IN_PROPERTY).toString().split(",");
+      for (String jackInDep : jackInDeps) {
+        project.getLogger().lifecycle("Jacking {} into the {} configuration", jackInDep, ClojureCommonPlugin.NREPL_CONFIGURATION_NAME);
+        project.getDependencies().add(ClojureCommonPlugin.NREPL_CONFIGURATION_NAME, jackInDep);
+      }
+    } else {
+      project.getDependencies().add(ClojureCommonPlugin.NREPL_CONFIGURATION_NAME, "nrepl:nrepl:0.9.0");
+    }
   }
 }

--- a/src/main/java/dev/clojurephant/plugin/common/internal/ClojureCommonPlugin.java
+++ b/src/main/java/dev/clojurephant/plugin/common/internal/ClojureCommonPlugin.java
@@ -47,9 +47,7 @@ public class ClojureCommonPlugin implements Plugin<Project> {
     SourceSet test = sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME);
     SourceSet dev = sourceSets.create(DEV_SOURCE_SET_NAME);
 
-    Configuration nrepl = project.getConfigurations().create(NREPL_CONFIGURATION_NAME);
-    project.getDependencies().add(NREPL_CONFIGURATION_NAME, "nrepl:nrepl:0.9.0");
-
+    Configuration nrepl = project.getConfigurations().getByName(NREPL_CONFIGURATION_NAME);
     project.getConfigurations().getByName(dev.getCompileClasspathConfigurationName()).extendsFrom(nrepl);
     project.getConfigurations().getByName(dev.getRuntimeClasspathConfigurationName()).extendsFrom(nrepl);
 


### PR DESCRIPTION
Editor integrations, such as Cider and Calva (maybe others), rely on being able to inject dependencies when starting nREPL in order to ensure they have all of the capabilities their editors use.

Eventually, this could be supported natively by Gradle via [1], but this has been a long-nagging issue with Gradle that made for a poorer user experience than Leiningen, Boot, tools.deps, etc.

Since this is just a Gradle property, it can be provided by editors even if the project isn't using Clojurephant (or the right version of Clojurephant), meaning a graceful degradation to the old experience of requiring the user to have put the right deps on the nREPL classpath.

[1] https://github.com/gradle/gradle/issues/17251

This fixes Clojurephant's side of #78.

<!-- Why is this change being made? -->

**Related issues:**

## Contributor Checklist

- [x] Review [Contributing Guidelines](https://github.com/clojurephant/clojurephant/blob/master/.github/CONTRIBUTING.md).
- [x] Commits contain discrete changes, messages include context about why the change was made and reference the relevant issues.
- [x] Commit messages should be prefixed with one of the following (these are used to determine the next version we release):
  - `patch: ` if the change added no new functionality and is backwards compatible
  - `minor: ` if the change added new functionality and is backwards compatible
  - `major: ` if the change is not backwards compatible
  - `chore: ` if the change doesn't affect plugin logic/behavior at all (and obviously still backwards compatible)
  - Any of these can optionally specify an area of the plugin they affected in parentheses (e.g. `patch(clojurescript): `)
    - `build`
    - `docs`
    - `clojure`
    - `clojurescript`
    - `common`
    - `repl`
- [x] Provide functional tests. (under `clojurephant-plugin/src/compatTest`)
- [ ] Update documentation for user-facing changes. (under `docs/`)
- [x] Ensure all verification tasks pass locally. (`./gradlew check`)
- [x] Ensure CI builds pass on all Java versions. (watch the checks tab once the PR is opened)

**TIP:** If troubleshooting a CI failure, look for the build scan URL in the workflow run summary.
