### PR TITLE
Support JVM toolchain for Clojure tasks

### DIFF
--- a/docs/modules/reference/pages/dsl/clojureextension.adoc
+++ b/docs/modules/reference/pages/dsl/clojureextension.adoc
@@ -17,8 +17,8 @@ Entry point to the DSL for configuring Clojure builds.
 |Root directory builds output dirs will conventionally be children of
 
 |builds
-|link:https://docs.gradle.org/current/javadoc/org/gradle/api/NamedDomainObjectContainer.html[NamedDomainObjectContainer<ClojureBuild>]
-|Container of all xref:dsl/clojurebuild.adoc[`ClojureBuild`]s for this project
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/NamedDomainObjectContainer.html[NamedDomainObjectContainer]<xref:dsl/clojurebuild.adoc[ClojureBuild]>
+|Container of all builds for this project
 |===
 
 == Methods

--- a/docs/modules/reference/pages/dsl/clojurescriptextension.adoc
+++ b/docs/modules/reference/pages/dsl/clojurescriptextension.adoc
@@ -17,8 +17,8 @@ Entry point to the DSL for configuring ClojureScript builds.
 |Root directory builds output dirs will conventionally be children of
 
 |builds
-|link:https://docs.gradle.org/current/javadoc/org/gradle/api/NamedDomainObjectContainer.html[NamedDomainObjectContainer<ClojureScriptBuild>]
-|Container of all xref:dsl/clojurescriptbuild.adoc[`ClojureScriptBuild`]s for this project
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/NamedDomainObjectContainer.html[NamedDomainObjectContainer]<xref:dsl/clojurescriptbuild.adoc[ClojureScriptBuild]>
+|Container of all builds for this project
 |===
 
 == Methods

--- a/docs/modules/reference/pages/tasks/clojurecheck.adoc
+++ b/docs/modules/reference/pages/tasks/clojurecheck.adoc
@@ -32,6 +32,10 @@ _None_
 |link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<String>]
 |One of `silent`, `warn`, `fail`. Controls whether reflection causes warnings or failures
 
+|javaLauncher
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property]<link:https://docs.gradle.org/current/javadoc/org/gradle/jvm/toolchain/JavaLauncher.html[JavaLauncher]>
+|Overrides the Java executable to use for the task's JVM
+
 |forkOptions
 |link:https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/compile/ForkOptions.html[ForkOptions]
 |Configure JVM settings

--- a/docs/modules/reference/pages/tasks/clojurecompile.adoc
+++ b/docs/modules/reference/pages/tasks/clojurecompile.adoc
@@ -36,6 +36,10 @@ _None_
 |link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/SetProperty.html[SetProperty<String>]
 |Namespaces within `source` that should be checked
 
+|javaLauncher
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property]<link:https://docs.gradle.org/current/javadoc/org/gradle/jvm/toolchain/JavaLauncher.html[JavaLauncher]>
+|Overrides the Java executable to use for the task's JVM
+
 |forkOptions
 |link:https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/compile/ForkOptions.html[ForkOptions]
 |Configure JVM settings

--- a/docs/modules/reference/pages/tasks/clojurenrepl.adoc
+++ b/docs/modules/reference/pages/tasks/clojurenrepl.adoc
@@ -52,6 +52,10 @@ $ ./gradlew clojureRepl --port=7555
 |link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/ListProperty.html[ListProperty<String>]
 |A sequence of vars, representing middleware you wish to mix in to the nREPL handler.
 
+|javaLauncher
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property]<link:https://docs.gradle.org/current/javadoc/org/gradle/jvm/toolchain/JavaLauncher.html[JavaLauncher]>
+|Overrides the Java executable to use for the task's JVM
+
 |forkOptions
 |link:https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/compile/ForkOptions.html[ForkOptions]
 |Configure JVM settings

--- a/docs/modules/reference/pages/tasks/clojurescriptcompile.adoc
+++ b/docs/modules/reference/pages/tasks/clojurescriptcompile.adoc
@@ -32,6 +32,10 @@ _None_
 |xref:dsl/clojurescriptcompileoptions.adoc[]
 |Options provided to the ClojureScript compiler
 
+|javaLauncher
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property]<link:https://docs.gradle.org/current/javadoc/org/gradle/jvm/toolchain/JavaLauncher.html[JavaLauncher]>
+|Overrides the Java executable to use for the task's JVM
+
 |forkOptions
 |link:https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/compile/ForkOptions.html[ForkOptions]
 |Configure JVM settings

--- a/manual-test/build.gradle
+++ b/manual-test/build.gradle
@@ -3,6 +3,12 @@ plugins {
   id 'dev.clojurephant.clojurescript'
 }
 
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(17)
+  }
+}
+
 repositories {
   mavenCentral()
   maven {

--- a/src/main/java/dev/clojurephant/plugin/clojure/tasks/ClojureCheck.java
+++ b/src/main/java/dev/clojurephant/plugin/clojure/tasks/ClojureCheck.java
@@ -47,7 +47,7 @@ import org.gradle.api.tasks.compile.ForkOptions;
 import org.gradle.process.ExecOperations;
 import us.bpsm.edn.Symbol;
 
-public abstract class ClojureCheck extends DefaultTask {
+public abstract class ClojureCheck extends DefaultTask implements ClojureTask {
   private static final Logger logger = Logging.getLogger(ClojureCompile.class);
   private static final Pattern REFLECTION_WARNING = Pattern.compile("Reflection warning, (.+?):.*");
 
@@ -81,9 +81,6 @@ public abstract class ClojureCheck extends DefaultTask {
   @Input
   public abstract Property<String> getReflection();
 
-  @Nested
-  public abstract ForkOptions getForkOptions();
-
   @Input
   public abstract SetProperty<String> getNamespaces();
 
@@ -104,6 +101,7 @@ public abstract class ClojureCheck extends DefaultTask {
         .plus(getProjectLayout().files(getTemporaryDir()));
 
     PreplClient preplClient = prepl.start(spec -> {
+      spec.setJavaLauncher(getJavaLauncher().getOrNull());
       spec.setClasspath(classpath);
       spec.setPort(0);
       spec.forkOptions(fork -> {

--- a/src/main/java/dev/clojurephant/plugin/clojure/tasks/ClojureCompile.java
+++ b/src/main/java/dev/clojurephant/plugin/clojure/tasks/ClojureCompile.java
@@ -39,7 +39,7 @@ import org.gradle.api.tasks.compile.ForkOptions;
 import org.gradle.process.ExecOperations;
 import us.bpsm.edn.Symbol;
 
-public abstract class ClojureCompile extends DefaultTask {
+public abstract class ClojureCompile extends DefaultTask implements ClojureTask {
   private static final Logger logger = Logging.getLogger(ClojureCompile.class);
 
   private final Prepl prepl;
@@ -67,9 +67,6 @@ public abstract class ClojureCompile extends DefaultTask {
 
   @Nested
   public abstract Property<ClojureCompileOptions> getOptions();
-
-  @Nested
-  public abstract ForkOptions getForkOptions();
 
   @Input
   public abstract SetProperty<String> getNamespaces();
@@ -101,6 +98,7 @@ public abstract class ClojureCompile extends DefaultTask {
         .plus(getProjectLayout().files(outputDir));
 
     PreplClient preplClient = prepl.start(spec -> {
+      spec.setJavaLauncher(getJavaLauncher().getOrNull());
       spec.setClasspath(classpath);
       spec.setPort(0);
       spec.forkOptions(fork -> {

--- a/src/main/java/dev/clojurephant/plugin/clojure/tasks/ClojureNRepl.java
+++ b/src/main/java/dev/clojurephant/plugin/clojure/tasks/ClojureNRepl.java
@@ -26,7 +26,7 @@ import org.gradle.api.tasks.compile.ForkOptions;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.process.ExecOperations;
 
-public abstract class ClojureNRepl extends DefaultTask {
+public abstract class ClojureNRepl extends DefaultTask implements ClojureTask {
   private final ForkOptions forkOptions = new ForkOptions();
 
   @Inject
@@ -54,6 +54,9 @@ public abstract class ClojureNRepl extends DefaultTask {
         .collect(Collectors.toList());
 
     getExecOperations().javaexec(spec -> {
+      if (getJavaLauncher().isPresent()) {
+        spec.setExecutable(getJavaLauncher().get().getExecutablePath());
+      }
       spec.setClasspath(cp);
       spec.getMainClass().set("clojure.main");
 
@@ -81,11 +84,6 @@ public abstract class ClojureNRepl extends DefaultTask {
       spec.setDefaultCharacterEncoding(StandardCharsets.UTF_8.name());
     }).assertNormalExitValue();
     System.out.println("nREPL server stopped");
-  }
-
-  @Nested
-  public ForkOptions getForkOptions() {
-    return forkOptions;
   }
 
   @Classpath

--- a/src/main/java/dev/clojurephant/plugin/clojure/tasks/ClojureTask.java
+++ b/src/main/java/dev/clojurephant/plugin/clojure/tasks/ClojureTask.java
@@ -1,0 +1,17 @@
+package dev.clojurephant.plugin.clojure.tasks;
+
+import org.gradle.api.Task;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.compile.ForkOptions;
+import org.gradle.jvm.toolchain.JavaLauncher;
+
+public interface ClojureTask extends Task {
+  @Nested
+  @Optional
+  public Property<JavaLauncher> getJavaLauncher();
+
+  @Nested
+  public ForkOptions getForkOptions();
+}

--- a/src/main/java/dev/clojurephant/plugin/clojurescript/tasks/ClojureScriptCompile.java
+++ b/src/main/java/dev/clojurephant/plugin/clojurescript/tasks/ClojureScriptCompile.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import dev.clojurephant.plugin.clojure.tasks.ClojureTask;
 import dev.clojurephant.plugin.common.internal.ClojureException;
 import dev.clojurephant.plugin.common.internal.Edn;
 import dev.clojurephant.plugin.common.internal.Namespaces;
@@ -32,7 +33,7 @@ import org.gradle.api.tasks.compile.ForkOptions;
 import org.gradle.process.ExecOperations;
 import us.bpsm.edn.Symbol;
 
-public abstract class ClojureScriptCompile extends DefaultTask {
+public abstract class ClojureScriptCompile extends DefaultTask implements ClojureTask {
   private final Prepl prepl;
 
   @Inject
@@ -56,9 +57,6 @@ public abstract class ClojureScriptCompile extends DefaultTask {
   @Nested
   public abstract Property<ClojureScriptCompileOptions> getOptions();
 
-  @Nested
-  public abstract ForkOptions getForkOptions();
-
   @Inject
   protected abstract FileSystemOperations getFileSystemOperations();
 
@@ -72,6 +70,7 @@ public abstract class ClojureScriptCompile extends DefaultTask {
     }
 
     PreplClient preplClient = prepl.start(spec -> {
+      spec.setJavaLauncher(getJavaLauncher().getOrNull());
       spec.setClasspath(getClasspath());
       spec.setPort(0);
       spec.forkOptions(fork -> {

--- a/src/main/java/dev/clojurephant/plugin/common/internal/ClojureCommonBasePlugin.java
+++ b/src/main/java/dev/clojurephant/plugin/common/internal/ClojureCommonBasePlugin.java
@@ -1,10 +1,16 @@
 package dev.clojurephant.plugin.common.internal;
 
+import dev.clojurephant.plugin.clojure.tasks.ClojureTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.plugins.JavaBasePlugin;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.TaskContainer;
+import org.gradle.jvm.toolchain.JavaLauncher;
+import org.gradle.jvm.toolchain.JavaToolchainService;
 
 public class ClojureCommonBasePlugin implements Plugin<Project> {
   public static final String NREPL_JACK_IN_PROPERTY = "dev.clojurephant.jack-in.nrepl";
@@ -12,7 +18,19 @@ public class ClojureCommonBasePlugin implements Plugin<Project> {
   @Override
   public void apply(Project project) {
     project.getPluginManager().apply(JavaBasePlugin.class);
+    configureJavaToolchain(project);
     configureNreplDependencies(project);
+  }
+
+  public void configureJavaToolchain(Project project) {
+    JavaPluginExtension java = project.getExtensions().getByType(JavaPluginExtension.class);
+    JavaToolchainService javaToolchain = project.getExtensions().getByType(JavaToolchainService.class);
+
+    Provider<JavaLauncher> launcher = javaToolchain.launcherFor(java.getToolchain());
+
+    project.getTasks().withType(ClojureTask.class, task -> {
+      task.getJavaLauncher().set(launcher);
+    });
   }
 
   public void configureNreplDependencies(Project project) {

--- a/src/main/java/dev/clojurephant/plugin/common/internal/Prepl.java
+++ b/src/main/java/dev/clojurephant/plugin/common/internal/Prepl.java
@@ -39,6 +39,9 @@ public class Prepl {
     new Thread(() -> {
       try {
         execOperations.javaexec(spec -> {
+          if (preplSpec.getJavaLauncher() != null) {
+            spec.setExecutable(preplSpec.getJavaLauncher().getExecutablePath());
+          }
           spec.getMainClass().set("clojure.main");
           spec.systemProperty("clojure.server.clojurephant", String.format("{:port %d :accept clojure.core.server/io-prepl :client-daemon false}", port));
           spec.args("-e", "(do (ns dev.clojurephant.prepl) (def connected (promise)) @connected nil)");

--- a/src/main/java/dev/clojurephant/plugin/common/internal/PreplSpec.java
+++ b/src/main/java/dev/clojurephant/plugin/common/internal/PreplSpec.java
@@ -5,12 +5,22 @@ import java.util.List;
 
 import org.gradle.api.Action;
 import org.gradle.api.file.FileCollection;
+import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.process.JavaForkOptions;
 
 public class PreplSpec {
+  private JavaLauncher javaLauncher;
   private FileCollection classpath;
   private int port;
   private List<Action<JavaForkOptions>> configureFork = new ArrayList<>();
+
+  public JavaLauncher getJavaLauncher() {
+    return javaLauncher;
+  }
+
+  public void setJavaLauncher(JavaLauncher javaLauncher) {
+    this.javaLauncher = javaLauncher;
+  }
 
   public FileCollection getClasspath() {
     return classpath;


### PR DESCRIPTION
Allow all Clojure tasks to specify a JavaLauncher. This is part of Gradle's JVM toolchain [1] feature allowing decoupling the JVM version Gradle uses from the JVM used for tasks.

Now all tasks Clojurephant provides have a common base interface ClojureTask the support fork options and java launcher.

This also picks up the JavaToolchain on the JavaPluginExtension and applies it by default to all ClojureTasks.

Fixes #174

[1] https://docs.gradle.org/current/userguide/toolchains.html
Add JavaLauncher to all tasks

<!-- Why is this change being made? -->

**Related issues:**

## Contributor Checklist

- [x] Review [Contributing Guidelines](https://github.com/clojurephant/clojurephant/blob/master/.github/CONTRIBUTING.md).
- [x] Commits contain discrete changes, messages include context about why the change was made and reference the relevant issues.
- [x] Commit messages should be prefixed with one of the following (these are used to determine the next version we release):
  - `patch: ` if the change added no new functionality and is backwards compatible
  - `minor: ` if the change added new functionality and is backwards compatible
  - `major: ` if the change is not backwards compatible
  - `chore: ` if the change doesn't affect plugin logic/behavior at all (and obviously still backwards compatible)
  - Any of these can optionally specify an area of the plugin they affected in parentheses (e.g. `patch(clojurescript): `)
    - `build`
    - `docs`
    - `clojure`
    - `clojurescript`
    - `common`
    - `repl`
- [ ] Provide functional tests. (under `clojurephant-plugin/src/compatTest`)
- [x] Update documentation for user-facing changes. (under `docs/`)
- [x] Ensure all verification tasks pass locally. (`./gradlew check`)
- [x] Ensure CI builds pass on all Java versions. (watch the checks tab once the PR is opened)

**TIP:** If troubleshooting a CI failure, look for the build scan URL in the workflow run summary.
