### PR TITLE
Prepare for tooling API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,11 @@ bin/
 \#*\#
 .\#*
 *~
+
+# Clojure
+.calva/
+.clj-kondo/
+.lsp/
+.nrepl-port
+*.edn
+

--- a/src/main/java/dev/clojurephant/plugin/clojurescript/tasks/ClojureScriptCompile.java
+++ b/src/main/java/dev/clojurephant/plugin/clojurescript/tasks/ClojureScriptCompile.java
@@ -87,7 +87,7 @@ public abstract class ClojureScriptCompile extends DefaultTask implements Clojur
       List<?> form = Edn.list(
           Symbol.newSymbol("api", "build"),
           Edn.list(Symbol.newSymbol("apply"), Symbol.newSymbol("api", "inputs"), getSource()),
-          getOptions());
+          Edn.list(Symbol.newSymbol("quote"), getOptions()));
       preplClient.evalData(form);
       preplClient.evalEdn("(.flush *err*)");
     } catch (ClojureException e) {

--- a/src/main/java/dev/clojurephant/plugin/common/ClojurephantModel.java
+++ b/src/main/java/dev/clojurephant/plugin/common/ClojurephantModel.java
@@ -1,0 +1,35 @@
+package dev.clojurephant.plugin.common;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class ClojurephantModel implements Serializable {
+  private String edn;
+
+  public ClojurephantModel(String edn) {
+    this.edn = Objects.requireNonNull(edn, "EDN must not be null.");;
+  }
+
+  public String getEdn() {
+    return edn;
+  }
+
+  @Override
+  public boolean equals(Object that) {
+    if (that instanceof ClojurephantModel) {
+      return this.edn.equals(((ClojurephantModel) that).edn);
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return edn.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return edn;
+  }
+}

--- a/src/main/java/dev/clojurephant/plugin/common/internal/ClojureCommonBasePlugin.java
+++ b/src/main/java/dev/clojurephant/plugin/common/internal/ClojureCommonBasePlugin.java
@@ -1,5 +1,7 @@
 package dev.clojurephant.plugin.common.internal;
 
+import javax.inject.Inject;
+
 import dev.clojurephant.plugin.clojure.tasks.ClojureTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -11,15 +13,24 @@ import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry;
 
 public class ClojureCommonBasePlugin implements Plugin<Project> {
   public static final String NREPL_JACK_IN_PROPERTY = "dev.clojurephant.jack-in.nrepl";
+
+  private final ToolingModelBuilderRegistry registry;
+
+  @Inject
+  public ClojureCommonBasePlugin(ToolingModelBuilderRegistry registry) {
+    this.registry = registry;
+  }
 
   @Override
   public void apply(Project project) {
     project.getPluginManager().apply(JavaBasePlugin.class);
     configureJavaToolchain(project);
     configureNreplDependencies(project);
+    registry.register(new ClojurephantModelBuilder());
   }
 
   public void configureJavaToolchain(Project project) {

--- a/src/main/java/dev/clojurephant/plugin/common/internal/ClojureCommonPlugin.java
+++ b/src/main/java/dev/clojurephant/plugin/common/internal/ClojureCommonPlugin.java
@@ -66,18 +66,20 @@ public class ClojureCommonPlugin implements Plugin<Project> {
     project.getConfigurations().getByName(dev.getCompileClasspathConfigurationName()).extendsFrom(nrepl);
     project.getConfigurations().getByName(dev.getRuntimeClasspathConfigurationName()).extendsFrom(nrepl);
 
-    Function<SourceSet, FileCollection> clojureSources = sourceSet -> {
-      ConfigurableFileCollection result = project.files();
-      SourceDirectorySet clojure = (SourceDirectorySet) sourceSet.getExtensions().findByName(ClojureBasePlugin.SOURCE_DIRECTORY_SET_NAME);
-      if (clojure != null) {
-        result.from(clojure.getSourceDirectories());
-      }
-      SourceDirectorySet clojureScript = (SourceDirectorySet) sourceSet.getExtensions().findByName(ClojureScriptBasePlugin.SOURCE_DIRECTORY_SET_NAME);
-      if (clojureScript != null) {
-        result.from(clojureScript.getSourceDirectories());
-      }
-      result.from(sourceSet.getResources().getSourceDirectories());
-      return result;
+    Function<SourceSet, Provider<FileCollection>> clojureSources = sourceSet -> {
+      return project.provider(() -> {
+        ConfigurableFileCollection result = project.files();
+        SourceDirectorySet clojure = (SourceDirectorySet) sourceSet.getExtensions().findByName(ClojureBasePlugin.SOURCE_DIRECTORY_SET_NAME);
+        if (clojure != null) {
+          result.from(clojure.getSourceDirectories());
+        }
+        SourceDirectorySet clojureScript = (SourceDirectorySet) sourceSet.getExtensions().findByName(ClojureScriptBasePlugin.SOURCE_DIRECTORY_SET_NAME);
+        if (clojureScript != null) {
+          result.from(clojureScript.getSourceDirectories());
+        }
+        result.from(sourceSet.getResources().getSourceDirectories());
+        return result;
+      });
     };
 
     dev.setCompileClasspath(project.files(

--- a/src/main/java/dev/clojurephant/plugin/common/internal/ClojurephantModelBuilder.java
+++ b/src/main/java/dev/clojurephant/plugin/common/internal/ClojurephantModelBuilder.java
@@ -1,0 +1,42 @@
+package dev.clojurephant.plugin.common.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import dev.clojurephant.plugin.clojure.ClojureExtension;
+import dev.clojurephant.plugin.clojurescript.ClojureScriptExtension;
+import dev.clojurephant.plugin.common.ClojurephantModel;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.tooling.provider.model.ToolingModelBuilder;
+
+public class ClojurephantModelBuilder implements ToolingModelBuilder {
+  @Override
+  public Object buildAll(String modelName, Project project) {
+    Map<String, Object> modelData = new HashMap<>();
+    ClojureExtension clojure = project.getExtensions().findByType(ClojureExtension.class);
+    if (clojure != null) {
+      modelData.put("clojure", clojure.getBuilds());
+    }
+
+    ClojureScriptExtension clojurescript = project.getExtensions().findByType(ClojureScriptExtension.class);
+    if (clojurescript != null) {
+      modelData.put("clojurescript", clojurescript.getBuilds());
+    }
+
+    Task repl = project.getTasks().findByName(ClojureCommonPlugin.NREPL_TASK_NAME);
+    if (repl != null) {
+      Map<String, Object> replData = new HashMap<>();
+      replData.put("path", repl.getPath());
+      replData.put("dir", repl.getTemporaryDir());
+      modelData.put("repl", Edn.keywordize(replData));
+    }
+
+    return new ClojurephantModel(Edn.print(Edn.keywordize(modelData)));
+  }
+
+  @Override
+  public boolean canBuild(String modelName) {
+    return ClojurephantModel.class.getCanonicalName().equals(modelName);
+  }
+}

--- a/src/main/java/dev/clojurephant/plugin/common/internal/Edn.java
+++ b/src/main/java/dev/clojurephant/plugin/common/internal/Edn.java
@@ -121,10 +121,9 @@ public class Edn {
       return null;
     }
 
-    List<Symbol> syms = preloads.stream()
+    return preloads.stream()
         .map(Symbol::newSymbol)
         .collect(Collectors.toList());
-    return list(Symbol.newSymbol("quote"), syms);
   }
 
   private static final Printer.Fn<ForeignLib> FOREIGN_LIB_PRINTER = (self, printer) -> {

--- a/src/main/java/dev/clojurephant/plugin/common/internal/Edn.java
+++ b/src/main/java/dev/clojurephant/plugin/common/internal/Edn.java
@@ -75,6 +75,7 @@ public class Edn {
   private static final Printer.Fn<ClojureScriptBuild> CLOJURESCRIPT_BUILD_PRINTER = (self, printer) -> {
     Map<Object, Object> root = new LinkedHashMap<>();
     root.put(newKeyword("name"), self.getName());
+    root.put(newKeyword("source-paths"), self.getSourceRoots());
     root.put(newKeyword("output-dir"), self.getOutputDir().map(Directory::getAsFile).getOrNull());
     root.put(newKeyword("compiler"), self.getCompiler());
     printer.printValue(root);

--- a/src/main/java/dev/clojurephant/plugin/common/internal/Edn.java
+++ b/src/main/java/dev/clojurephant/plugin/common/internal/Edn.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import dev.clojurephant.plugin.clojure.ClojureBuild;
 import dev.clojurephant.plugin.clojure.tasks.ClojureCompileOptions;
 import dev.clojurephant.plugin.clojurescript.ClojureScriptBuild;
 import dev.clojurephant.plugin.clojurescript.tasks.ClojureScriptCompileOptions;
@@ -49,7 +50,7 @@ public class Edn {
   };
 
   private static final Printer.Fn<NamedDomainObjectCollection<?>> NAMED_DOMAIN_PRINTER = (self, printer) -> {
-    printer.printValue(self.isEmpty() ? null : self.getAsMap());
+    printer.printValue(self.isEmpty() ? null : keywordize(self.getAsMap()));
   };
 
   private static final Printer.Fn<Provider<?>> PROVIDER_PRINTER = (self, printer) -> printer.printValue(self.getOrNull());
@@ -64,8 +65,16 @@ public class Edn {
     printer.printValue(root);
   };
 
+  private static final Printer.Fn<ClojureBuild> CLOJURE_BUILD_PRINTER = (self, printer) -> {
+    Map<Object, Object> root = new LinkedHashMap<>();
+    root.put(newKeyword("name"), self.getName());
+    root.put(newKeyword("compiler"), self.getCompiler());
+    printer.printValue(root);
+  };
+
   private static final Printer.Fn<ClojureScriptBuild> CLOJURESCRIPT_BUILD_PRINTER = (self, printer) -> {
     Map<Object, Object> root = new LinkedHashMap<>();
+    root.put(newKeyword("name"), self.getName());
     root.put(newKeyword("output-dir"), self.getOutputDir().map(Directory::getAsFile).getOrNull());
     root.put(newKeyword("compiler"), self.getCompiler());
     printer.printValue(root);
@@ -168,6 +177,7 @@ public class Edn {
       .put(Provider.class, PROVIDER_PRINTER)
       // Clojure
       .put(ClojureCompileOptions.class, CLOJURE_COMPILE_OPTIONS_PRINTER)
+      .put(ClojureBuild.class, CLOJURE_BUILD_PRINTER)
       // ClojureScript
       .put(ClojureScriptBuild.class, CLOJURESCRIPT_BUILD_PRINTER)
       .put(ClojureScriptCompileOptions.class, CLOJURESCRIPT_COMPILE_OPTIONS_PRINTER)


### PR DESCRIPTION
Covers a number of small changes needed to support [the tooling API library](https://github.com/clojurephant/clojurephant-tooling).

**Related issues:**

## Contributor Checklist

- [x] Review [Contributing Guidelines](https://github.com/clojurephant/clojurephant/blob/master/.github/CONTRIBUTING.md).
- [x] Commits contain discrete changes, messages include context about why the change was made and reference the relevant issues.
- [x] Commit messages should be prefixed with one of the following (these are used to determine the next version we release):
  - `patch: ` if the change added no new functionality and is backwards compatible
  - `minor: ` if the change added new functionality and is backwards compatible
  - `major: ` if the change is not backwards compatible
  - `chore: ` if the change doesn't affect plugin logic/behavior at all (and obviously still backwards compatible)
  - Any of these can optionally specify an area of the plugin they affected in parentheses (e.g. `patch(clojurescript): `)
    - `build`
    - `docs`
    - `clojure`
    - `clojurescript`
    - `common`
    - `repl`
- [ ] Provide functional tests. (under `clojurephant-plugin/src/compatTest`)
- [ ] Update documentation for user-facing changes. (under `docs/`)
- [x] Ensure all verification tasks pass locally. (`./gradlew check`)
- [x] Ensure CI builds pass on all Java versions. (watch the checks tab once the PR is opened)

**TIP:** If troubleshooting a CI failure, look for the build scan URL in the workflow run summary.
