### PR TITLE
minor(clojurescript): Add back Figwheel support

### DIFF
--- a/docs/modules/reference/pages/dsl/clojurescriptbuild.adoc
+++ b/docs/modules/reference/pages/dsl/clojurescriptbuild.adoc
@@ -31,6 +31,10 @@ Represents ClojureScript source code that should be compiled as a unit.
 |compiler
 |xref:dsl/clojurescriptcompileoptions.adoc[]
 |Configure the ClojureScript compiler for the build's xref:tasks/clojurescriptcompile.adoc[] task
+
+|figwheel
+|xref:dsl/figwheeloptions.adoc[]
+|Configure Figwheel options for use by xref:clojurephant-tooling::index.adoc[clojurephant-tooling]
 |===
 
 == Methods
@@ -42,6 +46,9 @@ Represents ClojureScript source code that should be compiled as a unit.
 
 |void compiler(Action<? super ClojureScriptCompilerOptions> action)
 |Allows configuring the compiler options in a block
+
+|void figwheel(Action<? super FigwheelOptions> action)
+|Allows configuring the figwheel options in a block
 |===
 
 == Example

--- a/docs/modules/reference/pages/dsl/figwheeloptions.adoc
+++ b/docs/modules/reference/pages/dsl/figwheeloptions.adoc
@@ -1,0 +1,132 @@
+= FigwheelOptions
+
+**Source:** link:https://github.com/clojurephant/clojurephant/blob/{page-origin-refname}/src/main/java/dev/clojurephant/plugin/clojurescript/tasks/FigwheelOptions.java[`dev.clojurephant.plugin.clojurescript.tasks.FigwheelOptions`]
+
+Options for Figwheel (see link:https://figwheel.org/config-options[Figwheel's documentation]).
+
+== Properties
+
+NOTE: Not all Figwheel options are supported yet. Open an issue or submit a PR if there's one you'd like added.
+
+[cols="2*m,1a", options="header"]
+|===
+|Property
+|Type
+|Description
+
+|targetDir
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/file/DirectoryProperty.html[DirectoryProperty]
+|Defaults to the build's `outputDir`
+
+|watchDirs
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/file/ConfigurableFileCollection.html[ConfigurableFileCollection]
+|
+
+|cssDirs
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/file/ConfigurableFileCollection.html[ConfigurableFileCollection]
+|
+
+|ringHandler
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<String>]
+|
+
+|ringServerOptions
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/MapProperty.html[MapProperty<String, Object>]
+|
+
+|rebelReadline
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<Boolean>]
+|Defaults to `false` (overriding Figwheel's default)
+
+|pprintConfig
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<Boolean>]
+|
+
+|openFileCommand
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<String>]
+|
+
+|figwheelCore
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<Boolean>]
+|
+
+|hotReloadCljs
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<Boolean>]
+|
+
+|connectUrl
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<String>]
+|
+
+|openUrl
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<Object>]
+|
+
+|reloadCljFiles
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<String>]
+|
+
+|logFile
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/file/RegularFileProperty.html[RegularFileProperty]
+|
+
+|logLevel
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<String>]
+|
+
+|clientLogLevel
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<String>]
+|
+
+|logSyntaxErrorStyle
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<String>]
+|
+
+|loadWarningedCode
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<Boolean>]
+|
+
+|ansiColorOutput
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<Boolean>]
+|
+
+|validateConfig
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<Boolean>]
+|
+
+|validateCli
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<Boolean>]
+|
+
+|launchNode
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<Boolean>]
+|
+
+|inspectNode
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<Boolean>]
+|
+
+|nodeCommand
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<String>]
+|
+
+|launchJs
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<String>]
+|
+
+|cljsDevtools
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<Boolean>]
+|
+
+|helpfulClasspaths
+|link:https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html[Property<Boolean>]
+|Defaults to `false` (overriding Figwheel's default)
+|===
+
+== Methods
+
+_None_
+
+== Example
+
+See xref:dsl/clojurescriptextension.adoc[].

--- a/src/main/java/dev/clojurephant/plugin/clojurescript/ClojureScriptBasePlugin.java
+++ b/src/main/java/dev/clojurephant/plugin/clojurescript/ClojureScriptBasePlugin.java
@@ -89,6 +89,11 @@ public class ClojureScriptBasePlugin implements Plugin<Project> {
         module.getBaseOutputDirectory().set(build.getCompiler().getBaseOutputDirectory());
       });
 
+      build.getFigwheel().getTargetDir().set(build.getOutputDir());
+      build.getFigwheel().getWatchDirs().from(build.getSourceRoots());
+      build.getFigwheel().getRebelReadline().set(false);
+      build.getFigwheel().getHelpfulClasspaths().set(false);
+
       String compileTaskName = build.getTaskName("compile");
       TaskProvider<ClojureScriptCompile> compileTask = project.getTasks().register(compileTaskName, ClojureScriptCompile.class, task -> {
         task.setDescription(String.format("Compiles the ClojureScript source for the %s build.", build.getName()));

--- a/src/main/java/dev/clojurephant/plugin/clojurescript/ClojureScriptBuild.java
+++ b/src/main/java/dev/clojurephant/plugin/clojurescript/ClojureScriptBuild.java
@@ -1,6 +1,7 @@
 package dev.clojurephant.plugin.clojurescript;
 
 import dev.clojurephant.plugin.clojurescript.tasks.ClojureScriptCompileOptions;
+import dev.clojurephant.plugin.clojurescript.tasks.FigwheelOptions;
 import org.apache.commons.text.WordUtils;
 import org.gradle.api.Action;
 import org.gradle.api.Named;
@@ -36,6 +37,13 @@ public abstract class ClojureScriptBuild implements Named {
 
   public void compiler(Action<? super ClojureScriptCompileOptions> configureAction) {
     configureAction.execute(getCompiler());
+  }
+
+  @Nested
+  public abstract FigwheelOptions getFigwheel();
+
+  public void figwheel(Action<? super FigwheelOptions> configureAction) {
+    configureAction.execute(getFigwheel());
   }
 
   String getTaskName(String task) {

--- a/src/main/java/dev/clojurephant/plugin/clojurescript/ClojureScriptPlugin.java
+++ b/src/main/java/dev/clojurephant/plugin/clojurescript/ClojureScriptPlugin.java
@@ -11,5 +11,16 @@ public class ClojureScriptPlugin implements Plugin<Project> {
   public void apply(Project project) {
     project.getPlugins().apply(ClojureScriptBasePlugin.class);
     project.getPlugins().apply(ClojureCommonPlugin.class);
+    configureFigwheel(project);
+  }
+
+  public void configureFigwheel(Project project) {
+    ClojureScriptExtension extension = project.getExtensions().getByType(ClojureScriptExtension.class);
+    ClojureScriptBuild main = extension.getBuilds().getByName("main");
+    ClojureScriptBuild test = extension.getBuilds().getByName("test");
+    ClojureScriptBuild dev = extension.getBuilds().getByName("dev");
+
+    dev.getFigwheel().getWatchDirs().from(main.getSourceRoots());
+    dev.getFigwheel().getWatchDirs().from(test.getSourceRoots());
   }
 }

--- a/src/main/java/dev/clojurephant/plugin/clojurescript/tasks/FigwheelOptions.java
+++ b/src/main/java/dev/clojurephant/plugin/clojurescript/tasks/FigwheelOptions.java
@@ -1,0 +1,102 @@
+package dev.clojurephant.plugin.clojurescript.tasks;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.gradle.api.Project;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.Directory;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.OutputFile;
+
+public abstract class FigwheelOptions {
+  @OutputDirectory
+  public abstract DirectoryProperty getTargetDir();
+
+  @InputFiles
+  public abstract ConfigurableFileCollection getWatchDirs();
+
+  @InputFiles
+  public abstract ConfigurableFileCollection getCssDirs();
+
+  @Input
+  public abstract Property<String> getRingHandler();
+
+  @Input
+  public abstract MapProperty<String, Object> getRingServerOptions();
+
+  @Input
+  public abstract Property<Boolean> getRebelReadline();
+
+  @Input
+  public abstract Property<Boolean> getPprintConfig();
+
+  @Input
+  public abstract Property<String> getOpenFileCommand();
+
+  @Input
+  public abstract Property<Boolean> getFigwheelCore();
+
+  @Input
+  public abstract Property<Boolean> getHotReloadCljs();
+
+  @Input
+  public abstract Property<String> getConnectUrl();
+
+  @Input
+  public abstract Property<Object> getOpenUrl();
+
+  @Input
+  public abstract Property<String> getReloadCljFiles();
+
+  @OutputFile
+  public abstract RegularFileProperty getLogFile();
+
+  @Input
+  public abstract Property<String> getLogLevel();
+
+  @Input
+  public abstract Property<String> getClientLogLevel();
+
+  @Input
+  public abstract Property<String> getLogSyntaxErrorStyle();
+
+  @Input
+  public abstract Property<Boolean> getLoadWarningedCode();
+
+  @Input
+  public abstract Property<Boolean> getAnsiColorOutput();
+
+  @Input
+  public abstract Property<Boolean> getValidateConfig();
+
+  @Input
+  public abstract Property<Boolean> getValidateCli();
+
+  @Input
+  public abstract Property<Boolean> getLaunchNode();
+
+  @Input
+  public abstract Property<Boolean> getInspectNode();
+
+  @Input
+  public abstract Property<String> getNodeCommand();
+
+  @Input
+  public abstract Property<String> getLaunchJs();
+
+  @Input
+  public abstract Property<Boolean> getCljsDevtools();
+
+  @Input
+  public abstract Property<Boolean> getHelpfulClasspaths();
+
+  // skipping remaining options for now
+}


### PR DESCRIPTION
Adding support for configuring Figwheel options on the ClojureScript
build. This will have no direct behavior in the plugin, but can be
read from the tooling lib.

<!-- Why is this change being made? -->

**Related issues:**

## Contributor Checklist

- [x] Review [Contributing Guidelines](https://github.com/clojurephant/clojurephant/blob/master/.github/CONTRIBUTING.md).
- [x] Commits contain discrete changes, messages include context about why the change was made and reference the relevant issues.
- [x] Commit messages should be prefixed with one of the following (these are used to determine the next version we release):
  - `patch: ` if the change added no new functionality and is backwards compatible
  - `minor: ` if the change added new functionality and is backwards compatible
  - `major: ` if the change is not backwards compatible
  - `chore: ` if the change doesn't affect plugin logic/behavior at all (and obviously still backwards compatible)
  - Any of these can optionally specify an area of the plugin they affected in parentheses (e.g. `patch(clojurescript): `)
    - `build`
    - `docs`
    - `clojure`
    - `clojurescript`
    - `common`
    - `repl`
- [x] Provide functional tests. (under `clojurephant-plugin/src/compatTest`)
- [x] Update documentation for user-facing changes. (under `docs/`)
- [x] Ensure all verification tasks pass locally. (`./gradlew check`)
- [x] Ensure CI builds pass on all Java versions. (watch the checks tab once the PR is opened)

**TIP:** If troubleshooting a CI failure, look for the build scan URL in the workflow run summary.
