### PR TITLE
patch: Accommodate Gradle 8 internal API changes

### DIFF
--- a/src/compatTest/clojure/dev/clojurephant/compat_test/test_kit.clj
+++ b/src/compatTest/clojure/dev/clojurephant/compat_test/test_kit.clj
@@ -63,18 +63,16 @@
     (is (= sources jar-entries))))
 
 (defn runner [args]
+  (println "***** Args:" args "*****")
   (let [gradle-version (System/getProperty "compat.gradle.version")
-        gradle-major-version (Integer/parseInt (re-find #"^\d+\." gradle-version))
-        args (cond-> args
-               true
-               (conj "--stacktrace")
-               (< gradle-major-version 8)
-               (conj "--configuration-cache"))]
-    (println "***** Args:" args "*****")
+        gradle-major-version (Integer/parseInt (re-find #"^\d+(?=\.)" gradle-version))
+        extra-flags (cond-> ["--stacktrace"]
+                      (< gradle-major-version 8)
+                      (conj "--configuration-cache"))]
     (-> (GradleRunner/create)
         (.withGradleVersion gradle-version)
         (.withProjectDir (-> *project-dir* .toFile))
-        (.withArguments (into-array String args))
+        (.withArguments (into-array String (concat args extra-flags)))
         (.withPluginClasspath)
         (.forwardOutput))))
 

--- a/src/main/java/dev/clojurephant/plugin/clojure/ClojureBuild.java
+++ b/src/main/java/dev/clojurephant/plugin/clojure/ClojureBuild.java
@@ -2,12 +2,16 @@ package dev.clojurephant.plugin.clojure;
 
 import java.util.Set;
 
+import javax.inject.Inject;
+
 import dev.clojurephant.plugin.clojure.tasks.ClojureCompileOptions;
 import dev.clojurephant.plugin.common.internal.Namespaces;
 import org.apache.commons.text.WordUtils;
 import org.gradle.api.Action;
 import org.gradle.api.Named;
+import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.provider.Property;
@@ -27,9 +31,33 @@ public abstract class ClojureBuild implements Named {
     return getSourceRoots().getAsFileTree();
   }
 
+  // For the usage of `observeSourceTreeHack`, below
+  @Inject
+  protected abstract Project getProject();
+
+  private void observeSourceTreeHack() {
+    Project project = getProject();
+    if (project.getGradle().getGradleVersion().matches("^[0-7]\\.")) {
+      // Gradle 7 or older
+      Instrumented.fileCollectionObserved(getSourceTree(), "Clojurephant");
+    } else {
+      // Gradle 8 or newer
+      // Hack: call getFiles() on a ConfigurableFileTree specifically.
+      // This marks the files as inputs to the build configuration.
+      // https://github.com/gradle/gradle/pull/23265
+      // Can be removed when https://github.com/gradle/gradle/issues/20265 has landed.
+      //
+      // Note: to reduce the number of loop iterations, call getSourceRoots().forEach()
+      // instead of getSourceTree().forEach()
+      getSourceRoots().forEach(file -> {
+        ConfigurableFileTree configurableFileTree = project.fileTree(file);
+        configurableFileTree.getFiles();
+      });
+    }
+  }
+
   Provider<Set<String>> getAllNamespaces() {
-    // Using internal API due to https://github.com/gradle/gradle/issues/20265
-    Instrumented.fileCollectionObserved(getSourceTree(), "Clojurephant");
+    observeSourceTreeHack();
     return Namespaces.findNamespaces(getSourceTree());
   }
 


### PR DESCRIPTION
<!-- Why is this change being made? -->

I ran into #206 earlier today.

I think I have a hack that enables Gradle 8 compatibility without sacrificing Gradle 7.

The reason a hack is necessary: the functionality of `Instrumented.fileCollectionObserved` was removed at the exact same time that the new-style approach was added. (https://github.com/gradle/gradle/commit/e4355b87b8ffc775cc005724853a10f95b1a58c8)

As a result:
* If this plugin uses `Instrumented.fileCollectionObserved`, then it can't run in Gradle 8+, nor even compile against it
* But if this plugin DOESN'T use `Instrumented.fileCollectionObserved`, then its 'build configuration input' logic is broken in Gradle 7

To make matters more interesting, the replacement functionality for `Instrumented.fileCollectionObserved` is still in an incubating state. We must specifically obtain a `ConfigurableFileTree` to use it.

Bearing all that in mind, I think this hack will work for Gradle 7 and 8. (Later, if you want to upgrade the plugin's gradle wrapper to 8, you could use reflection to invoke the Gradle 7 method.)

**Related issues:**
#206

## Contributor Checklist

- [x] Review [Contributing Guidelines](https://github.com/clojurephant/clojurephant/blob/master/.github/CONTRIBUTING.md).
- [x] Commits contain discrete changes, messages include context about why the change was made and reference the relevant issues.
- [x] Commit messages should be prefixed with one of the following (these are used to determine the next version we release):
  - `patch: ` if the change added no new functionality and is backwards compatible
  - `minor: ` if the change added new functionality and is backwards compatible
  - `major: ` if the change is not backwards compatible
  - `chore: ` if the change doesn't affect plugin logic/behavior at all (and obviously still backwards compatible)
  - Any of these can optionally specify an area of the plugin they affected in parentheses (e.g. `patch(clojurescript): `)
    - `build`
    - `docs`
    - `clojure`
    - `clojurescript`
    - `common`
    - `repl`
- [x] Provide functional tests. (under `clojurephant-plugin/src/compatTest`)
- [x] Update documentation for user-facing changes. (under `docs/`)
- [x] Ensure all verification tasks pass locally. (`./gradlew check`)
- [x] Ensure CI builds pass on all Java versions. (watch the checks tab once the PR is opened)

**TIP:** If troubleshooting a CI failure, look for the build scan URL in the workflow run summary.
