### PR TITLE
Update Shadow links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Gradle plugin providing support for the Clojure and ClojureScript languages.
 ### Clojure Features
 
 - Packaging Clojure code (and/or AOT compiled classes) into a JAR
-- Package an Uberjar (via the Gradle [Shadow plugin](http://imperceptiblethoughts.com/shadow/))
+- Package an Uberjar (via the Gradle [Shadow plugin](https://gradleup.com/shadow/))
 - AOT compilation
 - Running clojure.test tests (integrated into Gradle's [Test task](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.testing.Test.html))
 - Running an nREPL server (supports custom middlewares or handler)

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -16,7 +16,7 @@ In particular, if you have a need to interop with Java code (maybe even other JV
 
 Features provided by Gradle (or its ecosystem) that are useful for Clojure programmers.
 
-* Packaging into ZIPs, JARs, or Uberjars (via the third-party link:http://imperceptiblethoughts.com/shadow/[Shadow plugin])
+* Packaging into ZIPs, JARs, or Uberjars (via the third-party link:https://gradleup.com/shadow/[Shadow plugin])
 * Multi-project builds
 * Publishing to Maven repositories (such as Clojars or Maven Central)
 

--- a/docs/modules/howto/pages/faq.adoc
+++ b/docs/modules/howto/pages/faq.adoc
@@ -53,7 +53,7 @@ Then run the `publish` task.
 
 == How do I create an uberjar?
 
-Use the Gradle link:http://imperceptiblethoughts.com/shadow/[Shadow plugin].
+Use the Gradle link:https://gradleup.com/shadow/[Shadow plugin].
 
 === Configuration
 
@@ -96,7 +96,7 @@ Ensure your main namespace has `(:gen-class)` in the `ns` declaration:
 
 === More information
 
-Read the link:http://imperceptiblethoughts.com/shadow/[Shadow Plugin User Guide]. for full details on their other features.
+Read the link:https://gradleup.com/shadow/[Shadow Plugin User Guide]. for full details on their other features.
 
 == How do I build Clojure code that depends on Java code?
 


### PR DESCRIPTION
<!-- Why is this change being made? -->

The repo is transferred to https://github.com/GradleUp/shadow, and the doc site is redirected to https://gradleup.com/shadow.

## Contributor Checklist

- [x] Review [Contributing Guidelines](https://github.com/clojurephant/clojurephant/blob/master/.github/CONTRIBUTING.md).
- [x] Commits contain discrete changes, messages include context about why the change was made and reference the relevant issues.
- [ ] Commit messages should be prefixed with one of the following (these are used to determine the next version we release):
  - `patch: ` if the change added no new functionality and is backwards compatible
  - `minor: ` if the change added new functionality and is backwards compatible
  - `major: ` if the change is not backwards compatible
  - `chore: ` if the change doesn't affect plugin logic/behavior at all (and obviously still backwards compatible)
  - Any of these can optionally specify an area of the plugin they affected in parentheses (e.g. `patch(clojurescript): `)
    - `build`
    - `docs`
    - `clojure`
    - `clojurescript`
    - `common`
    - `repl`
- [ ] Provide functional tests. (under `clojurephant-plugin/src/compatTest`)
- [x] Update documentation for user-facing changes. (under `docs/`)
- [ ] Ensure all verification tasks pass locally. (`./gradlew check`)
- [ ] Ensure CI builds pass on all Java versions. (watch the checks tab once the PR is opened)

**TIP:** If troubleshooting a CI failure, look for the build scan URL in the workflow run summary.
